### PR TITLE
Reset mapper, if multiple deserializers used they maintain stage.

### DIFF
--- a/src/main/java/com/zendesk/maxwell/row/RowMapDeserializer.java
+++ b/src/main/java/com/zendesk/maxwell/row/RowMapDeserializer.java
@@ -204,4 +204,8 @@ public class RowMapDeserializer extends StdDeserializer<RowMap> {
 	{
 		return getMapper(encryption_key,secret_key).readValue(json, RowMap.class);
 	}
+
+	public static void resetMapper(){
+		mapper = null;
+	}
 }


### PR DESCRIPTION
Since object mapper is static and once it is initialized for a Deserializer with no encryption it does not reset it for Deserializer with encryption.  So it creates a problem if we need to utilize multiple ways to deserialize, which occurred in running all junit tests. 

Creating a reset method seemed least intrusive way to work around this problem. But this is open for discussion if we want to make different design strategy.

@BradyPT @abacaphiliac @r4j4h 